### PR TITLE
Add local gradle dependencies

### DIFF
--- a/examples/xo_android_client/app/build.gradle
+++ b/examples/xo_android_client/app/build.gradle
@@ -23,7 +23,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation files('libs/sawtooth-sdk-signing-v0.1.2-SNAPSHOT.jar')
+    implementation files('libs/sawtooth-sdk-protos-v0.1.2-SNAPSHOT.jar')
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'


### PR DESCRIPTION
The sawtooth-sdk had to be compiled locally with jdk 1.8 for android.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>


To test put the two jars in `xo_android_client/app/libs/` and build the project.